### PR TITLE
Added group template setting to Importer Rules.

### DIFF
--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -29,6 +29,12 @@ public enum LabelWriteMode
     Replace
 }
 
+public enum GroupTemplateApplicationMode
+{
+    ApplyOnGroupCreationOnly,
+    AlwaysOverwriteGroupSettings
+}
+
 [System.Serializable]
 public class AddressableImportRule
 {
@@ -66,6 +72,12 @@ public class AddressableImportRule
     /// </summary>
     [Tooltip("Group template that will be applied to the Addressable Group. Leave none to use the Default Group's settings.")]
     public AddressableAssetGroupTemplate groupTemplate = null;
+
+    /// <summary>
+    /// Controls wether group template will be applied only on group creation, or also to already created groups.
+    /// </summary>
+    [Tooltip("Defines if the group template will only be applied to new groups, or will also overwrite existing groups settings.")]
+    public GroupTemplateApplicationMode groupTemplateApplicationMode = GroupTemplateApplicationMode.ApplyOnGroupCreationOnly;
 
     /// <summary>
     /// Simplify address.

--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using UnityEditor.AddressableAssets.Settings;
 using UnityEngine.AddressableAssets;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -59,6 +60,12 @@ public class AddressableImportRule
     /// </summary>
     [Tooltip("The list of labels to be added to the Addressable Asset")]
     public List<AssetLabelReference> labelRefs;
+
+    /// <summary>
+    /// Group template to use. Default Group settings will be used if empty.
+    /// </summary>
+    [Tooltip("Group template that will be applied to the Addressable Group. Leave none to use the Default Group's settings.")]
+    public AddressableAssetGroupTemplate groupTemplate = null;
 
     /// <summary>
     /// Simplify address.

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -62,12 +62,14 @@ public class AddressableImporter : AssetPostprocessor
         // Set group
         AddressableAssetGroup group;
         var groupName = rule.ParseGroupReplacement(assetPath);
+        bool newGroup = false;
         if (!TryGetGroup(settings, groupName, out group))
         {
             if (importSettings.allowGroupCreation)
             {
                 //TODO Specify on editor which type to create.
                 group = CreateAssetGroup<BundledAssetGroupSchema>(settings, groupName);
+                newGroup = true;
             }
             else
             {
@@ -77,7 +79,7 @@ public class AddressableImporter : AssetPostprocessor
         }
 
         // Set group settings from template if necessary
-        if (rule.groupTemplate != null)
+        if (rule.groupTemplate != null && (newGroup || rule.groupTemplateApplicationMode == GroupTemplateApplicationMode.AlwaysOverwriteGroupSettings))
         {
             rule.groupTemplate.ApplyToAddressableAssetGroup(group);
         }

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -75,6 +75,13 @@ public class AddressableImporter : AssetPostprocessor
                 return null;
             }
         }
+
+        // Set group settings from template if necessary
+        if (rule.groupTemplate != null)
+        {
+            rule.groupTemplate.ApplyToAddressableAssetGroup(group);
+        }
+
         var guid = AssetDatabase.AssetPathToGUID(assetPath);
         var entry = settings.CreateOrMoveEntry(guid, group);
 


### PR DESCRIPTION
This allows the user to select from the available group templates.
All found assets will apply the template's settings to new or already existing groups.

This does not change the default behavior, it only adds some customization options to the rules.

Not sure if that interests you but we needed this for our project!