### PR TITLE
Apply import rules to moved assets.

### DIFF
--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -15,15 +15,6 @@ public class AddressableImporter : AssetPostprocessor
 {
     static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
     {
-        foreach (var assetPath in importedAssets)
-        {
-            Debug.Log("imported : " + assetPath);
-        }
-        foreach (var assetPath in movedAssets)
-        {
-            Debug.Log("moved : " + assetPath);
-            
-        }
         var settings = AddressableAssetSettingsDefaultObject.Settings;
         if (settings == null)
         {


### PR DESCRIPTION
This allows the import rules to be applied to moved assets as well.
Also, delete the entry if there are no rules to apply as a result of the move.