### PR TITLE
Fix for 'Remove Empty Groups' removing non-empty groups

### DIFF
--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -14,7 +14,7 @@ using UnityEditor.Experimental.SceneManagement;
 public class AddressableImporter : AssetPostprocessor
 {
     static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
-    {
+    {        
         var settings = AddressableAssetSettingsDefaultObject.Settings;
         if (settings == null)
         {
@@ -47,14 +47,19 @@ public class AddressableImporter : AssetPostprocessor
                 dirty |= ApplyImportRule(movedAsset, movedFromAssetPath, settings, importSettings);
         }
 
-        // Remove empty groups.
-        if (importSettings.removeEmtpyGroups)
+        // Avoid running the deletion step if we're importing addressables data - the addressables configuration
+        // can be in an incorrect state at this point causing groups that actually have entries to be deleted.
+        if (importedAssets.Any(x => x.StartsWith("Assets/AddressableAssetsData")))
         {
-            var emptyGroups = settings.groups.Where(x => x.entries.Count == 0 && !x.IsDefaultGroup()).ToArray();
-            for (var i = 0; i < emptyGroups.Length; i++)
+            // Remove empty groups.
+            if (importSettings.removeEmtpyGroups)
             {
-                settings.RemoveGroup(emptyGroups[i]);
-                dirty = true;
+                var emptyGroups = settings.groups.Where(x => x.entries.Count == 0 && !x.IsDefaultGroup()).ToArray();
+                for (var i = 0; i < emptyGroups.Length; i++)
+                {
+                    settings.RemoveGroup(emptyGroups[i]);
+                    dirty = true;
+                }
             }
         }
 

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -49,7 +49,7 @@ public class AddressableImporter : AssetPostprocessor
 
         // Avoid running the deletion step if we're importing addressables data - the addressables configuration
         // can be in an incorrect state at this point causing groups that actually have entries to be deleted.
-        if (importedAssets.Any(x => x.StartsWith("Assets/AddressableAssetsData")))
+        if (!importedAssets.Any(x => x.StartsWith("Assets/AddressableAssetsData")))
         {
             // Remove empty groups.
             if (importSettings.removeEmtpyGroups)

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -14,7 +14,7 @@ using UnityEditor.Experimental.SceneManagement;
 public class AddressableImporter : AssetPostprocessor
 {
     static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
-    {        
+    {
         var settings = AddressableAssetSettingsDefaultObject.Settings;
         if (settings == null)
         {


### PR DESCRIPTION
Addressables configuration data was being read while addressable configuration files were being imported. This leads to groups appearing to be empty when they're not - just because the data hasn't been read in yet.

This commit avoids running the deletion part of the post processor if one of these files is being imported.

This bug was reproduced in a test project with a number of assets each creating new groups based on a single rule. Without this fix, ticking "Remove Emtpy Groups" (note spelling mistake by the way) causes the groups to be created then immediately deleted as they appear to be empty briefly during the import process for the group configuration files.