### PR TITLE
Improve the inspector for AddressableImportSettings

### DIFF
--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -45,12 +45,12 @@ public class AddressableImportRule
     : ISearchFilterable
 {
     #region inspector
-    
+
     /// <summary>
-    /// Path pattern.
+    /// The group the asset will be added.
     /// </summary>
-    [Tooltip("The assets in this path will be processed.")]
-    public string path = string.Empty;
+    [Tooltip("The group name in which the Addressable will be added. Leave blank for the default group.")]
+    public string groupName = string.Empty;
 
     /// <summary>
     /// Method used to parse the Path.
@@ -59,10 +59,10 @@ public class AddressableImportRule
     public AddressableImportRuleMatchType matchType;
 
     /// <summary>
-    /// The group the asset will be added.
+    /// Path pattern.
     /// </summary>
-    [Tooltip("The group name in which the Addressable will be added. Leave blank for the default group.")]
-    public string groupName = string.Empty;
+    [Tooltip("The assets in this path will be processed.")]
+    public string path = string.Empty;
 
 
     /// <summary>
@@ -106,12 +106,12 @@ public class AddressableImportRule
     public string addressReplacement = string.Empty;
 
     #endregion
-    
-    
+
+
     private AddressableImportFilter _filter = new AddressableImportFilter();
     public AddressableImportFilter Filter => _filter ?? new AddressableImportFilter();
 
-    
+
     public bool HasLabelRefs
     {
         get
@@ -129,7 +129,7 @@ public class AddressableImportRule
     {
         return string.IsNullOrEmpty(searchString) || Filter.IsMatch(this,searchString);
     }
-    
+
     /// <summary>
     /// Returns True if given assetPath matched with the rule.
     /// </summary>

--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -47,37 +47,24 @@ public class AddressableImportRule
     #region inspector
 
     /// <summary>
-    /// The group the asset will be added.
-    /// </summary>
-    [Tooltip("The group name in which the Addressable will be added. Leave blank for the default group.")]
-    public string groupName = string.Empty;
-
-    /// <summary>
-    /// Method used to parse the Path.
-    /// </summary>
-    [Tooltip("The path parsing method.")]
-    public AddressableImportRuleMatchType matchType;
-
-    /// <summary>
     /// Path pattern.
     /// </summary>
     [Tooltip("The assets in this path will be processed.")]
     public string path = string.Empty;
 
+    /// <summary>
+    /// Method used to parse the Path.
+    /// </summary>
+    [Tooltip("The path parsing method.")]
+    [IndentField(1)]
+    public AddressableImportRuleMatchType matchType;
 
     /// <summary>
-    /// Defines if labels will be added or replaced.
+    /// The group the asset will be added.
     /// </summary>
-    public LabelWriteMode LabelMode;
-
-    /// <summary>
-    /// Label reference list.
-    /// </summary>
-    [Tooltip("The list of addressable labels (already existing in your project) to be added to the Addressable Asset")]
-    public List<AssetLabelReference> labelRefs;
-
-    [Tooltip("The list of dynamic labels to be added to the Addressable Asset. If an addressable label doesn't exist, then it will be create in your unity project")]
-    public List<string> dynamicLabels;
+    [Tooltip("The group name in which the Addressable will be added. Leave blank for the default group.")]
+    [Space]
+    public string groupName = string.Empty;
 
     /// <summary>
     /// Group template to use. Default Group settings will be used if empty.
@@ -89,13 +76,29 @@ public class AddressableImportRule
     /// Controls wether group template will be applied only on group creation, or also to already created groups.
     /// </summary>
     [Tooltip("Defines if the group template will only be applied to new groups, or will also overwrite existing groups settings.")]
+    [Label("Application Mode"), IndentField(1)]
     public GroupTemplateApplicationMode groupTemplateApplicationMode = GroupTemplateApplicationMode.ApplyOnGroupCreationOnly;
+
+    /// <summary>
+    /// Label reference list.
+    /// </summary>
+    [Tooltip("The list of addressable labels (already existing in your project) to be added to the Addressable Asset")]
+    [Space]
+    public List<AssetLabelReference> labelRefs;
+
+    [Tooltip("The list of dynamic labels to be added to the Addressable Asset. If an addressable label doesn't exist, then it will be create in your unity project")]
+    public List<string> dynamicLabels;
+
+    /// <summary>
+    /// Defines if labels will be added or replaced.
+    /// </summary>
+    public LabelWriteMode LabelMode;
 
     /// <summary>
     /// Simplify address.
     /// </summary>
     [Tooltip("Simplify address to filename without extension.")]
-    [Label("Address Simplified")]
+    [Label("Address Simplified"), Space]
     public bool simplified;
 
     /// <summary>

--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -76,7 +76,7 @@ public class AddressableImportRule
     /// Controls wether group template will be applied only on group creation, or also to already created groups.
     /// </summary>
     [Tooltip("Defines if the group template will only be applied to new groups, or will also overwrite existing groups settings.")]
-    [Label("Application Mode"), IndentField(1)]
+    [IndentLabel("Application Mode", 1)]
     public GroupTemplateApplicationMode groupTemplateApplicationMode = GroupTemplateApplicationMode.ApplyOnGroupCreationOnly;
 
     /// <summary>

--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -56,7 +56,6 @@ public class AddressableImportRule
     /// Method used to parse the Path.
     /// </summary>
     [Tooltip("The path parsing method.")]
-    [IndentField(1)]
     public AddressableImportRuleMatchType matchType;
 
     /// <summary>
@@ -76,7 +75,7 @@ public class AddressableImportRule
     /// Controls wether group template will be applied only on group creation, or also to already created groups.
     /// </summary>
     [Tooltip("Defines if the group template will only be applied to new groups, or will also overwrite existing groups settings.")]
-    [IndentLabel("Application Mode", 1)]
+    [Label("Application Mode")]
     public GroupTemplateApplicationMode groupTemplateApplicationMode = GroupTemplateApplicationMode.ApplyOnGroupCreationOnly;
 
     /// <summary>

--- a/Editor/AddressableImportSettings.cs
+++ b/Editor/AddressableImportSettings.cs
@@ -18,6 +18,7 @@ public class AddressableImportSettings : ScriptableObject
     [Tooltip("Creates a group if the specified group doesn't exist.")]
     public bool allowGroupCreation = false;
 
+    [Space]
     [Tooltip("Rules for managing imported assets.")]
 #if ODIN_INSPECTOR
     [ListDrawerSettings(HideAddButton = false,Expanded = false,DraggableItems = true,HideRemoveButton = false)]

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -22,6 +22,12 @@ namespace UnityAddressableImporter.Helper
         private const string RULE_FOLDOUT = "Rule";
         private static readonly string RULE_FOLDOUT_LABEL = $"@{PROP_PATH}";
 
+        private const string ADDRESSABLE_IMPORT_RULE_MATCH_TYPE = nameof(AddressableImportRuleMatchType);
+        private const string WILDCARD = nameof(AddressableImportRuleMatchType.Wildcard);
+        private static readonly string ADDRESS_REPLACEMENT_HIDE_IF =
+            $"@this.{PROP_MATCH_TYPE} == {ADDRESSABLE_IMPORT_RULE_MATCH_TYPE}.{WILDCARD} ||" +
+            $"this.{PROP_SIMPLIFIED} == true";
+
         private static readonly Color RULE_COLOR = Color.green;
         private static readonly FoldoutColorMode RULE_COLOR_MODE = FoldoutColorMode.OnExpanded;
         private static readonly FoldoutColorSelector RULE_COLOR_SELECTOR = FoldoutColorSelector.Header;
@@ -61,7 +67,7 @@ namespace UnityAddressableImporter.Helper
                     break;
 
                 case PROP_ADDRESS_REPLACEMENT:
-                    attributes.Add(new HideIfAttribute(PROP_MATCH_TYPE, AddressableImportRuleMatchType.Wildcard));
+                    attributes.Add(new HideIfAttribute(ADDRESS_REPLACEMENT_HIDE_IF));
                     break;
             }
         }

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -53,12 +53,7 @@ namespace UnityAddressableImporter.Helper
 
             switch (member.Name)
             {
-                case PROP_MATCH_TYPE:
-                    attributes.Add(new IndentAttribute());
-                    break;
-
                 case PROP_APPLICATION_MODE:
-                    attributes.Add(new IndentAttribute());
                     attributes.Add(new LabelTextAttribute("Application Mode"));
                     break;
 

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -30,7 +30,7 @@ namespace UnityAddressableImporter.Helper
         private const string RULE_FOLDOUT = "Rule";
         private static readonly string RULE_FOLDOUT_LABEL = $"@{PROP_GROUP_NAME}";
 
-        private static readonly string TITLE_PATH = $"{RULE_FOLDOUT}/Path";
+        private static readonly string TITLE_PATH = $"{RULE_FOLDOUT}/Asset Path";
         private static readonly string TITLE_TEMPLATE = $"{RULE_FOLDOUT}/Group Template";
         private static readonly string TITLE_ADDRESS = $"{RULE_FOLDOUT}/Address";
 

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -88,7 +88,6 @@ namespace UnityAddressableImporter.Helper
                     break;
 
                 case PROP_ADDRESS_REPLACEMENT:
-                    ProcessRuleGroup(attributes);
                     ProcessTitleGroup(attributes, TITLE_ADDRESS, "Replacement");
                     break;
             }

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -12,37 +12,19 @@ namespace UnityAddressableImporter.Helper
     public class AddressableImportRuleAttributeProcessor<T> : OdinAttributeProcessor<T>
         where T : AddressableImportRule
     {
-        private const string PROP_GROUP_NAME = nameof(AddressableImportRule.groupName);
-
         private const string PROP_PATH = nameof(AddressableImportRule.path);
         private const string PROP_MATCH_TYPE = nameof(AddressableImportRule.matchType);
-
-        private const string PROP_LABEL_MODE = nameof(AddressableImportRule.LabelMode);
-        private const string PROP_LABEL_REFS = nameof(AddressableImportRule.labelRefs);
-        private const string PROP_DYNAMIC_LABEL = nameof(AddressableImportRule.dynamicLabels);
-
-        private const string PROP_GROUP_TEMPLATE = nameof(AddressableImportRule.groupTemplate);
         private const string PROP_APPLICATION_MODE = nameof(AddressableImportRule.groupTemplateApplicationMode);
 
         private const string PROP_SIMPLIFIED = nameof(AddressableImportRule.simplified);
         private const string PROP_ADDRESS_REPLACEMENT = nameof(AddressableImportRule.addressReplacement);
 
         private const string RULE_FOLDOUT = "Rule";
-        private static readonly string RULE_FOLDOUT_LABEL = $"@{PROP_GROUP_NAME}";
-
-        private static readonly string TITLE_PATH = $"{RULE_FOLDOUT}/Asset Path";
-        private static readonly string TITLE_TEMPLATE = $"{RULE_FOLDOUT}/Group Template";
-        private static readonly string TITLE_ADDRESS = $"{RULE_FOLDOUT}/Address";
-
-        private static readonly string LABEL_FOLDOUT = $"{RULE_FOLDOUT}/Label";
-        private const string LABEL_FOLDOUT_LABEL = "Label";
+        private static readonly string RULE_FOLDOUT_LABEL = $"@{PROP_PATH}";
 
         private static readonly Color RULE_COLOR = Color.green;
         private static readonly FoldoutColorMode RULE_COLOR_MODE = FoldoutColorMode.OnExpanded;
         private static readonly FoldoutColorSelector RULE_COLOR_SELECTOR = FoldoutColorSelector.Header;
-
-        private static readonly Color LABEL_COLOR = Color.yellow;
-        private static readonly FoldoutColorMode LABEL_COLOR_MODE = FoldoutColorMode.OnExpanded;
 
         public override void ProcessChildMemberAttributes(
             InspectorProperty parentProperty,
@@ -52,50 +34,8 @@ namespace UnityAddressableImporter.Helper
             attributes.Add(new PropertySpaceAttribute(2));
             attributes.Add(new LabelWidthAttribute(130f));
 
-            switch (member.Name)
+            attributes.Add(new FoldoutColorGroupAttribute(RULE_FOLDOUT, RULE_FOLDOUT_LABEL)
             {
-                case PROP_GROUP_NAME:
-                    ProcessRuleGroup(attributes);
-                    break;
-
-                case PROP_PATH:
-                case PROP_MATCH_TYPE:
-                    attributes.Add(new TitleGroupAttribute(TITLE_PATH));
-                    break;
-
-                case PROP_LABEL_MODE:
-                    ProcessLabelGroup(attributes, "Mode");
-                    break;
-
-                case PROP_LABEL_REFS:
-                    ProcessLabelGroup(attributes, "References");
-                    break;
-
-                case PROP_DYNAMIC_LABEL:
-                    ProcessLabelGroup(attributes, "Dynamic");
-                    break;
-
-                case PROP_GROUP_TEMPLATE:
-                    ProcessTitleGroup(attributes, TITLE_TEMPLATE, "Template");
-                    break;
-
-                case PROP_APPLICATION_MODE:
-                    ProcessTitleGroup(attributes, TITLE_TEMPLATE, "Application Mode");
-                    break;
-
-                case PROP_SIMPLIFIED:
-                    ProcessTitleGroup(attributes, TITLE_ADDRESS, "Simplified");
-                    break;
-
-                case PROP_ADDRESS_REPLACEMENT:
-                    ProcessTitleGroup(attributes, TITLE_ADDRESS, "Replacement");
-                    break;
-            }
-        }
-
-        private static void ProcessRuleGroup(List<Attribute> attributes)
-        {
-            attributes.Add(new FoldoutColorGroupAttribute(RULE_FOLDOUT, RULE_FOLDOUT_LABEL) {
                 Color = RULE_COLOR,
                 ColorMode = RULE_COLOR_MODE,
                 ColorSelector = RULE_COLOR_SELECTOR,
@@ -104,26 +44,26 @@ namespace UnityAddressableImporter.Helper
                 MarginTop = 2,
                 MarginBottom = 5
             });
-        }
 
-        private static void ProcessTitleGroup(List<Attribute> attributes, string titleGroup, string label)
-        {
-            attributes.Add(new TitleGroupAttribute(titleGroup));
-            attributes.Add(new LabelTextAttribute(label));
-        }
+            switch (member.Name)
+            {
+                case PROP_MATCH_TYPE:
+                    attributes.Add(new IndentAttribute());
+                    break;
 
-        private static void ProcessLabelGroup(List<Attribute> attributes, string label)
-        {
-            attributes.Add(new FoldoutColorGroupAttribute(LABEL_FOLDOUT, LABEL_FOLDOUT_LABEL) {
-                Color = LABEL_COLOR,
-                ColorMode = LABEL_COLOR_MODE,
-                BoldLabel = true,
-                PaddingTop = 14,
-                MarginTop = 2,
-                MarginBottom = 3
-            });
+                case PROP_APPLICATION_MODE:
+                    attributes.Add(new IndentAttribute());
+                    attributes.Add(new LabelTextAttribute("Application Mode"));
+                    break;
 
-            attributes.Add(new LabelTextAttribute(label));
+                case PROP_SIMPLIFIED:
+                    attributes.Add(new LabelTextAttribute("Address Simplified"));
+                    break;
+
+                case PROP_ADDRESS_REPLACEMENT:
+                    attributes.Add(new HideIfAttribute(PROP_MATCH_TYPE, AddressableImportRuleMatchType.Wildcard));
+                    break;
+            }
         }
     }
 }

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs
@@ -1,0 +1,132 @@
+﻿#if ODIN_INSPECTOR
+
+namespace UnityAddressableImporter.Helper
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using UnityEngine;
+    using Sirenix.OdinInspector;
+    using Sirenix.OdinInspector.Editor;
+
+    public class AddressableImportRuleAttributeProcessor<T> : OdinAttributeProcessor<T>
+        where T : AddressableImportRule
+    {
+        private const string PROP_GROUP_NAME = nameof(AddressableImportRule.groupName);
+
+        private const string PROP_PATH = nameof(AddressableImportRule.path);
+        private const string PROP_MATCH_TYPE = nameof(AddressableImportRule.matchType);
+
+        private const string PROP_LABEL_MODE = nameof(AddressableImportRule.LabelMode);
+        private const string PROP_LABEL_REFS = nameof(AddressableImportRule.labelRefs);
+        private const string PROP_DYNAMIC_LABEL = nameof(AddressableImportRule.dynamicLabels);
+
+        private const string PROP_GROUP_TEMPLATE = nameof(AddressableImportRule.groupTemplate);
+        private const string PROP_APPLICATION_MODE = nameof(AddressableImportRule.groupTemplateApplicationMode);
+
+        private const string PROP_SIMPLIFIED = nameof(AddressableImportRule.simplified);
+        private const string PROP_ADDRESS_REPLACEMENT = nameof(AddressableImportRule.addressReplacement);
+
+        private const string RULE_FOLDOUT = "Rule";
+        private static readonly string RULE_FOLDOUT_LABEL = $"@{PROP_GROUP_NAME}";
+
+        private static readonly string TITLE_PATH = $"{RULE_FOLDOUT}/Path";
+        private static readonly string TITLE_TEMPLATE = $"{RULE_FOLDOUT}/Group Template";
+        private static readonly string TITLE_ADDRESS = $"{RULE_FOLDOUT}/Address";
+
+        private static readonly string LABEL_FOLDOUT = $"{RULE_FOLDOUT}/Label";
+        private const string LABEL_FOLDOUT_LABEL = "Label";
+
+        private static readonly Color RULE_COLOR = Color.green;
+        private static readonly FoldoutColorMode RULE_COLOR_MODE = FoldoutColorMode.OnExpanded;
+        private static readonly FoldoutColorSelector RULE_COLOR_SELECTOR = FoldoutColorSelector.Header;
+
+        private static readonly Color LABEL_COLOR = Color.yellow;
+        private static readonly FoldoutColorMode LABEL_COLOR_MODE = FoldoutColorMode.OnExpanded;
+
+        public override void ProcessChildMemberAttributes(
+            InspectorProperty parentProperty,
+            MemberInfo member,
+            List<Attribute> attributes)
+        {
+            attributes.Add(new PropertySpaceAttribute(2));
+            attributes.Add(new LabelWidthAttribute(130f));
+
+            switch (member.Name)
+            {
+                case PROP_GROUP_NAME:
+                    ProcessRuleGroup(attributes);
+                    break;
+
+                case PROP_PATH:
+                case PROP_MATCH_TYPE:
+                    attributes.Add(new TitleGroupAttribute(TITLE_PATH));
+                    break;
+
+                case PROP_LABEL_MODE:
+                    ProcessLabelGroup(attributes, "Mode");
+                    break;
+
+                case PROP_LABEL_REFS:
+                    ProcessLabelGroup(attributes, "References");
+                    break;
+
+                case PROP_DYNAMIC_LABEL:
+                    ProcessLabelGroup(attributes, "Dynamic");
+                    break;
+
+                case PROP_GROUP_TEMPLATE:
+                    ProcessTitleGroup(attributes, TITLE_TEMPLATE, "Template");
+                    break;
+
+                case PROP_APPLICATION_MODE:
+                    ProcessTitleGroup(attributes, TITLE_TEMPLATE, "Application Mode");
+                    break;
+
+                case PROP_SIMPLIFIED:
+                    ProcessTitleGroup(attributes, TITLE_ADDRESS, "Simplified");
+                    break;
+
+                case PROP_ADDRESS_REPLACEMENT:
+                    ProcessRuleGroup(attributes);
+                    ProcessTitleGroup(attributes, TITLE_ADDRESS, "Replacement");
+                    break;
+            }
+        }
+
+        private static void ProcessRuleGroup(List<Attribute> attributes)
+        {
+            attributes.Add(new FoldoutColorGroupAttribute(RULE_FOLDOUT, RULE_FOLDOUT_LABEL) {
+                Color = RULE_COLOR,
+                ColorMode = RULE_COLOR_MODE,
+                ColorSelector = RULE_COLOR_SELECTOR,
+                PaddingTop = 5,
+                PaddingBottom = 5,
+                MarginTop = 2,
+                MarginBottom = 5
+            });
+        }
+
+        private static void ProcessTitleGroup(List<Attribute> attributes, string titleGroup, string label)
+        {
+            attributes.Add(new TitleGroupAttribute(titleGroup));
+            attributes.Add(new LabelTextAttribute(label));
+        }
+
+        private static void ProcessLabelGroup(List<Attribute> attributes, string label)
+        {
+            attributes.Add(new FoldoutColorGroupAttribute(LABEL_FOLDOUT, LABEL_FOLDOUT_LABEL) {
+                Color = LABEL_COLOR,
+                ColorMode = LABEL_COLOR_MODE,
+                BoldLabel = true,
+                PaddingTop = 14,
+                MarginTop = 2,
+                MarginBottom = 3
+            });
+
+            attributes.Add(new LabelTextAttribute(label));
+        }
+    }
+}
+
+#endif

--- a/Editor/Helper/AddressableImportRuleAttributeProcessor.cs.meta
+++ b/Editor/Helper/AddressableImportRuleAttributeProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dfd57d0c28e7694387cf273d9bef146
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Helper/FoldoutColorGroupAttribute.cs
+++ b/Editor/Helper/FoldoutColorGroupAttribute.cs
@@ -130,6 +130,14 @@ namespace UnityAddressableImporter.Helper
         private ValueResolver<string> _groupNameResolver;
 #endif
 
+        private static readonly GUIStyle FOLDOUT_STYLE_BOLD;
+
+        static FoldoutColorGroupAttributeDrawer()
+        {
+            FOLDOUT_STYLE_BOLD = new GUIStyle(SirenixGUIStyles.Foldout);
+            FOLDOUT_STYLE_BOLD.fontStyle = FontStyle.Bold;
+        }
+
         private LocalPersistentContext<bool> _isExpanded;
 
         protected override void Initialize()
@@ -186,12 +194,9 @@ namespace UnityAddressableImporter.Helper
             if (colored && coloredAll)
                 GUIHelper.PopColor();
 
-            GUIStyle labelStyle = null;
 
-            if (Attribute.BoldLabel)
-                labelStyle = EditorStyles.boldLabel;
-
-            _isExpanded.Value = SirenixEditorGUI.Foldout(_isExpanded.Value, headerLabel, labelStyle);
+            var foldoutStyle = Attribute.BoldLabel ? FOLDOUT_STYLE_BOLD : SirenixGUIStyles.Foldout;
+            _isExpanded.Value = SirenixEditorGUI.Foldout(_isExpanded.Value, headerLabel, foldoutStyle);
 
             SirenixEditorGUI.EndBoxHeader();
 

--- a/Editor/Helper/FoldoutColorGroupAttribute.cs
+++ b/Editor/Helper/FoldoutColorGroupAttribute.cs
@@ -1,0 +1,243 @@
+﻿/// https://github.com/onewheelstudio/SirenixTutorialFiles/blob/master/CustomGroups/MyClass.cs
+
+namespace UnityAddressableImporter.Helper
+{
+    using UnityEngine;
+
+    public enum FoldoutColorMode
+    {
+        Always,
+        OnExpanded,
+        OnCollapsed
+    }
+
+    public enum FoldoutColorSelector
+    {
+        All,
+        Header
+    }
+
+    public partial class FoldoutColorGroupAttribute
+    {
+        public Color Color { get; set; }
+
+        public FoldoutColorMode ColorMode { get; set; }
+
+        public FoldoutColorSelector ColorSelector { get; set; }
+
+        public bool Expanded { get; set; }
+
+        public bool BoldLabel { get; set; }
+
+        public int PaddingTop { get; set; }
+
+        public int PaddingBottom { get; set; }
+
+        public int MarginTop { get; set; }
+
+        public int MarginBottom { get; set; }
+    }
+}
+
+#if !ODIN_INSPECTOR
+
+namespace UnityAddressableImporter.Helper
+{
+    using System;
+    using UnityEngine;
+
+    partial class FoldoutColorGroupAttribute : Attribute
+    {
+        public string Group { get; set; }
+
+        public string LabelText { get; set; }
+
+        public bool ShowLabel { get; set; }
+
+        public float Order { get; set; }
+
+        public FoldoutColorGroupAttribute(
+            string group,
+            string label = "",
+            float r = 1f, float g = 1f, float b = 1f,
+            bool expanded = false,
+            bool showLabel = true,
+            bool boldLabel = false,
+            float order = 0f)
+        {
+            Group = group;
+            Color = new Color(r, g, b, 1f);
+            LabelText = label;
+            Expanded = expanded;
+            ShowLabel = showLabel;
+            Order = order;
+            BoldLabel = boldLabel;
+        }
+    }
+}
+
+#endif
+
+#if ODIN_INSPECTOR
+
+namespace UnityAddressableImporter.Helper
+{
+    using System;
+    using Sirenix.OdinInspector;
+    using Sirenix.OdinInspector.Editor;
+    using Sirenix.OdinInspector.Editor.ValueResolvers;
+    using Sirenix.Utilities;
+    using Sirenix.Utilities.Editor;
+    using UnityEditor;
+    using UnityEngine;
+
+    partial class FoldoutColorGroupAttribute : BoxGroupAttribute
+    {
+        public FoldoutColorGroupAttribute(
+            string group,
+            string label = "",
+            float r = 1f, float g = 1f, float b = 1f,
+            bool expanded = false,
+            bool showLabel = true,
+            bool boldLabel = false,
+            float order = 0f)
+            : base(group, showLabel, false, order)
+        {
+            Color = new Color(r, g, b, 1f);
+            LabelText = label;
+            Expanded = expanded;
+            BoldLabel = boldLabel;
+        }
+
+        protected override void CombineValuesWith(PropertyGroupAttribute other)
+        {
+            var otherAttr = (FoldoutColorGroupAttribute)other;
+            var otherColor = otherAttr.Color;
+            var color = Color;
+
+            color.r = Math.Max(otherColor.r, Color.r);
+            color.g = Math.Max(otherColor.g, Color.g);
+            color.b = Math.Max(otherColor.b, Color.b);
+            color.a = Math.Max(otherColor.a, Color.a);
+
+            Color = color;
+        }
+    }
+
+    public class FoldoutColorGroupAttributeDrawer : OdinGroupDrawer<FoldoutColorGroupAttribute>
+    {
+#if ODIN_INSPECTOR_3
+        private ValueResolver<string> _groupNameResolver;
+#endif
+
+        private LocalPersistentContext<bool> _isExpanded;
+
+        protected override void Initialize()
+        {
+#if ODIN_INSPECTOR_3
+            _groupNameResolver = ValueResolver.GetForString(Property, Attribute.LabelText ?? Attribute.GroupName);
+#endif
+
+            _isExpanded = this.GetPersistentValue(
+                $"{nameof(FoldoutColorGroupAttributeDrawer)}.isExpanded",
+                Attribute.Expanded);
+        }
+
+        protected override void DrawPropertyLayout(GUIContent label)
+        {
+            var headerLabel = Attribute.LabelText;
+
+            if (Attribute.ShowLabel)
+            {
+#if ODIN_INSPECTOR_3
+                _groupNameResolver.DrawError();
+                headerLabel = _groupNameResolver.GetValue();
+#endif
+            }
+            else
+            {
+                headerLabel = string.Empty;
+            }
+
+            var colored = true;
+
+            switch (Attribute.ColorMode)
+            {
+                case FoldoutColorMode.OnExpanded:
+                    colored = _isExpanded.Value;
+                    break;
+
+                case FoldoutColorMode.OnCollapsed:
+                    colored = !_isExpanded.Value;
+                    break;
+            }
+
+            var coloredAll = Attribute.ColorSelector == FoldoutColorSelector.All;
+
+            GUILayout.Space(Attribute.PaddingTop);
+
+            if (colored && coloredAll)
+                GUIHelper.PushColor(Attribute.Color);
+
+            SirenixEditorGUI.BeginBox();
+
+            BeginBoxHeader(colored && !coloredAll, Attribute.Color);
+
+            if (colored && coloredAll)
+                GUIHelper.PopColor();
+
+            GUIStyle labelStyle = null;
+
+            if (Attribute.BoldLabel)
+                labelStyle = EditorStyles.boldLabel;
+
+            _isExpanded.Value = SirenixEditorGUI.Foldout(_isExpanded.Value, headerLabel, labelStyle);
+
+            SirenixEditorGUI.EndBoxHeader();
+
+            if (_isExpanded.Value)
+                GUILayout.Space(Attribute.MarginTop);
+
+            if (SirenixEditorGUI.BeginFadeGroup(this, _isExpanded.Value))
+            {
+                for (int i = 0; i < Property.Children.Count; i++)
+                {
+                    Property.Children[i].Draw();
+                }
+            }
+
+            SirenixEditorGUI.EndFadeGroup();
+
+            if (_isExpanded.Value)
+                GUILayout.Space(Attribute.MarginBottom);
+
+            SirenixEditorGUI.EndBox();
+            GUILayout.Space(Attribute.PaddingBottom);
+        }
+
+        private static Rect BeginBoxHeader(bool colored, Color color)
+        {
+            GUILayout.Space(-3f);
+            Rect rect = EditorGUILayout.BeginHorizontal(SirenixGUIStyles.BoxHeaderStyle, GUILayoutOptions.ExpandWidth());
+
+            if (Event.current.type == EventType.Repaint)
+            {
+                rect.x -= 3f;
+                rect.width += 6f;
+
+                color = colored ? color : SirenixGUIStyles.HeaderBoxBackgroundColor;
+                color.a = SirenixGUIStyles.HeaderBoxBackgroundColor.a;
+
+                GUIHelper.PushColor(color);
+                GUI.DrawTexture(rect, Texture2D.whiteTexture);
+                GUIHelper.PopColor();
+                SirenixEditorGUI.DrawBorders(rect, 0, 0, 0, 1, new Color(0f, 0f, 0f, 0.4f));
+            }
+
+            GUIHelper.PushLabelWidth(GUIHelper.BetterLabelWidth - 4f);
+            return rect;
+        }
+    }
+}
+
+#endif

--- a/Editor/Helper/FoldoutColorGroupAttribute.cs.meta
+++ b/Editor/Helper/FoldoutColorGroupAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6eb0440d27a6f61499fab9ff59915e94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Helper/IndentFieldAttribute.cs
+++ b/Editor/Helper/IndentFieldAttribute.cs
@@ -1,0 +1,47 @@
+﻿/// <summary>
+/// LabelAttribute,
+/// modified from https://github.com/dbrizov/NaughtyAttributes/blob/master/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/LabelPropertyDrawer.cs
+/// </summary>
+using System;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace UnityAddressableImporter.Helper
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class IndentFieldAttribute : PropertyAttribute
+    {
+        public int Level { get; private set; }
+
+        public IndentFieldAttribute(int level)
+        {
+            Level = Mathf.Max(level, 0);
+        }
+    }
+}
+
+#if UNITY_EDITOR && !ODIN_INSPECTOR
+namespace UnityAddressableImporter.Helper.Internal
+{
+    [CustomPropertyDrawer(typeof(IndentFieldAttribute))]
+    public class IndentFieldAttributeDrawer : PropertyDrawer
+    {
+        private IndentFieldAttribute Attribute
+        {
+            get { return _attribute ?? (_attribute = attribute as IndentFieldAttribute); }
+        }
+
+        private IndentFieldAttribute _attribute;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.indentLevel += Attribute.Level;
+            EditorGUI.PropertyField(position, property, label, true);
+            EditorGUI.indentLevel -= Attribute.Level;
+        }
+    }
+}
+#endif

--- a/Editor/Helper/IndentFieldAttribute.cs.meta
+++ b/Editor/Helper/IndentFieldAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa73472338a387148a529c691aadc184
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Helper/IndentLabelAttribute.cs
+++ b/Editor/Helper/IndentLabelAttribute.cs
@@ -1,0 +1,51 @@
+﻿/// <summary>
+/// LabelAttribute,
+/// modified from https://github.com/dbrizov/NaughtyAttributes/blob/master/Assets/NaughtyAttributes/Scripts/Editor/PropertyDrawers/LabelPropertyDrawer.cs
+/// </summary>
+using System;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace UnityAddressableImporter.Helper
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class IndentLabelAttribute : PropertyAttribute
+    {
+        public string Label { get; private set; }
+
+        public int Level { get; private set; }
+
+        public IndentLabelAttribute(string label, int level)
+        {
+            Label = label;
+            Level = Mathf.Max(level, 0);
+        }
+    }
+}
+
+#if UNITY_EDITOR && !ODIN_INSPECTOR
+namespace UnityAddressableImporter.Helper.Internal
+{
+    [CustomPropertyDrawer(typeof(IndentLabelAttribute))]
+    public class IndentLabelAttributeDrawer : PropertyDrawer
+    {
+        private IndentLabelAttribute Attribute
+        {
+            get { return _attribute ?? (_attribute = attribute as IndentLabelAttribute); }
+        }
+
+        private IndentLabelAttribute _attribute;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var guiContent = new GUIContent(Attribute.Label);
+            EditorGUI.indentLevel += Attribute.Level;
+            EditorGUI.PropertyField(position, property, guiContent, true);
+            EditorGUI.indentLevel -= Attribute.Level;
+        }
+    }
+}
+#endif

--- a/Editor/Helper/IndentLabelAttribute.cs.meta
+++ b/Editor/Helper/IndentLabelAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 203369918b4014b4eb613ed4e1b6d6f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Helper/LabelAttribute.cs
+++ b/Editor/Helper/LabelAttribute.cs
@@ -23,7 +23,7 @@ namespace UnityAddressableImporter.Helper
     }
 }
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !ODIN_INSPECTOR
 namespace UnityAddressableImporter.Helper.Internal
 {
     [CustomPropertyDrawer(typeof(LabelAttribute))]


### PR DESCRIPTION
Fix issue https://github.com/favoyang/unity-addressable-importer/issues/59
- [x] Change the order of rule properties a bit
- [x] Add `[Space]` before the list of rules
- [x] Use `OdinAttributeProcessor` to add attributes to the properties
- [x] Add a custom colored foldout group

![image](https://user-images.githubusercontent.com/1594982/147489913-114ab56b-c252-4c61-ae12-2e5647d512e8.png)

![image](https://user-images.githubusercontent.com/1594982/147489926-e72f9404-f367-4c61-ad8d-3451f7a964cc.png)

