### PR TITLE
Change namespace of PrefabStageUtility in Unity 2021.2

### DIFF
--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -9,7 +9,12 @@ using System.Linq;
 using System.IO;
 using System.Text.RegularExpressions;
 using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.SceneManagement;
+#else
 using UnityEditor.Experimental.SceneManagement;
+#endif
 
 public class AddressableImporter : AssetPostprocessor
 {


### PR DESCRIPTION
Since Unity 2021.2, `PrefabStageUtility` has been moved into `UnityEditor.SceneManagement` namespace.