### PR TITLE
Multiple AddressableImportSettings support

### DIFF
--- a/Editor/AddressableImportSettings.cs
+++ b/Editor/AddressableImportSettings.cs
@@ -12,9 +12,10 @@ using Sirenix.OdinInspector;
 [CreateAssetMenu(fileName = "AddressableImportSettings", menuName = "Addressable Assets/Import Settings", order = 50)]
 public class AddressableImportSettings : ScriptableObject
 {
-    public const string kDefaultConfigObjectName = "addressableimportsettings";
-    public const string kDefaultPath = "Assets/AddressableAssetsData/AddressableImportSettings.asset";
-
+    [Tooltip("Toggle rules enabled state")]
+    [SerializeField]
+    private bool rulesEnabled = true;
+    
     [Tooltip("Creates a group if the specified group doesn't exist.")]
     public bool allowGroupCreation = false;
 
@@ -58,19 +59,15 @@ public class AddressableImportSettings : ScriptableObject
         }
     }
 
-    public static AddressableImportSettings Instance
+    public static AddressableImportSettings[] Instances
     {
         get
         {
-            AddressableImportSettings so;
-            // Try to locate settings via EditorBuildSettings.
-            if (EditorBuildSettings.TryGetConfigObject(kDefaultConfigObjectName, out so))
-                return so;
-            // Try to locate settings via path.
-            so = AssetDatabase.LoadAssetAtPath<AddressableImportSettings>(kDefaultPath);
-            if (so != null)
-                EditorBuildSettings.AddConfigObject(kDefaultConfigObjectName, so, true);
-            return so;
+            return AssetDatabase.FindAssets($"t:{nameof(AddressableImportSettings)}")
+                .Select(guid =>
+                    AssetDatabase.LoadAssetAtPath<AddressableImportSettings>(AssetDatabase.GUIDToAssetPath(guid)))
+                .Where(settings => settings.rulesEnabled)
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
Update with AddressableImportSettings. Make settings more flexible and readable if you have a lot of rules by spliting to different scriptables.

- add multiple AddressableImportSettings support
- add rules enable state toggle
- add ability to place settings asset in any project folder (not Assets/AddressableAssetsData only)

![Screenshot_3](https://user-images.githubusercontent.com/38282199/150651081-d9cf23f0-1fd7-4d46-b681-0340c8d377be.png)
![Screenshot_4](https://user-images.githubusercontent.com/38282199/150651095-181a4b4d-e9da-4935-93fd-d516e9cc9c54.png)


Closes #66