### PR TITLE
Some optimization

### DIFF
--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -208,8 +208,12 @@ public class AddressableImporter : AssetPostprocessor
             rule.groupTemplate.ApplyToAddressableAssetGroup(group);
         }
 
+
+        // CreateOrMoveEntry is very slow, so don't move anything if the group is already the correct one
         var guid = AssetDatabase.AssetPathToGUID(assetPath);
-        var entry = settings.CreateOrMoveEntry(guid, group);
+        var entry = settings.FindAssetEntry(guid);
+        if (entry == null || entry.parentGroup != group)
+            entry = settings.CreateOrMoveEntry(guid, group);
 
         if (entry != null)
         {

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -71,12 +71,27 @@ public class AddressableImporter : AssetPostprocessor
 #else
         string prefabAssetPath = prefabStage != null ? prefabStage.prefabAssetPath : null;
 #endif
-        foreach (var importedAsset in importedAssets)
+        try
         {
-            if (IsAssetIgnored(importedAsset))
-                continue;
-            if (prefabStage == null || prefabAssetPath != importedAsset) // Ignore current editing prefab asset.
-                dirty |= ApplyImportRule(importedAsset, null, settings, importSettings);
+            for (var i = 0; i < importedAssets.Length; i++)
+            {
+                var importedAsset = importedAssets[i];
+
+                if (IsAssetIgnored(importedAsset))
+                    continue;
+
+                if (EditorUtility.DisplayCancelableProgressBar(
+                    "Processing addressable import settings", $"[{i}/{importedAssets.Length}] {importedAsset}",
+                    (float) i / importedAssets.Length))
+                    break;
+
+                if (prefabStage == null || prefabAssetPath != importedAsset) // Ignore current editing prefab asset.
+                    dirty |= ApplyImportRule(importedAsset, null, settings, importSettings);
+            }
+        }
+        finally
+        {
+            EditorUtility.ClearProgressBar();
         }
 
         for (var i = 0; i < movedAssets.Length; i++)

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -321,6 +321,12 @@ public class AddressableImporter : AssetPostprocessor
             if (pathsToImport.Count > 0)
             {
                 Debug.Log($"AddressableImporter: Found {pathsToImport.Count} asset paths...");
+
+                if (!EditorUtility.DisplayDialog("Process files?",
+                                                 $"About to process {pathsToImport.Count} files, is that OK?",
+                                                 "Yes", "No"))
+                    return;
+
                 OnPostprocessAllAssets(pathsToImport.ToArray(), new string[0], new string[0], new string[0]);
             }
         }


### PR DESCRIPTION
These changes make using this library a lot more bearable with a huge amount of assets:

- Before starting the import process, ask if the user really wants to do it, and show the amount of files to be processed
- Show a progress bar that allows to cancel the import
- Only run `CreateOrMoveEntry` if it's actually needed (the asset is not addressable or is in another group), because it's _very_ slow, since it deletes and recreates the entry in another group. This way, reimporting an asset that's already in a group it's supposed to be in takes pretty much no time.