### PR TITLE
feat: Add a setting to disable the progress bar on import

### DIFF
--- a/Editor/AddressableImportSettingsList.cs
+++ b/Editor/AddressableImportSettingsList.cs
@@ -11,6 +11,7 @@ public class AddressableImportSettingsList : ScriptableObject
     public const string kDefaultPath = "Assets/AddressableAssetsData/AddressableImportSettingsList.asset";
     public List<AddressableImportSettings> SettingList;
     public List<AddressableImportSettings> EnabledSettingsList => SettingList.Where((s) => s?.rulesEnabled == true).ToList();
+    public bool ShowImportProgressBar = true;
 
     public static AddressableImportSettingsList Instance
     {

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -91,7 +91,7 @@ public class AddressableImporter : AssetPostprocessor
                 if (IsAssetIgnored(importedAsset))
                     continue;
 
-                if (EditorUtility.DisplayCancelableProgressBar(
+                if (importSettingsList.ShowImportProgressBar && EditorUtility.DisplayCancelableProgressBar(
                     "Processing addressable import settings", $"[{i}/{importedAssets.Length}] {importedAsset}",
                     (float) i / importedAssets.Length))
                     break;


### PR DESCRIPTION
Hi @favoyang,

I have added a setting to disable the progress bar on import.
This is to prevent the progress bar from appearing momentarily each time a file is imported in a small project.
The default behavior remains the same.

I would be grateful if you could check this request.