### PR TITLE
Fix: entries removed from Groups window not re-created on reimport

### DIFF
--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -246,7 +246,11 @@ public class AddressableImporter : AssetPostprocessor
         // CreateOrMoveEntry is very slow, so don't move anything if the group is already the correct one
         var guid = AssetDatabase.AssetPathToGUID(assetPath);
         var entry = settings.FindAssetEntry(guid);
-        if (entry == null || entry.parentGroup != group)
+        // When manually removing an entry from the Addressables Groups window,
+        // it may remain in settings' GUID→Entry map but be removed from the group's entries list
+        // (a "zombie entry"). Check that the entry is actually present in the group before skipping CreateOrMoveEntry.
+        var isInGroup = entry != null && entry.parentGroup != null && entry.parentGroup.entries.Contains(entry);
+        if (entry == null || entry.parentGroup != group || !isInGroup)
             entry = settings.CreateOrMoveEntry(guid, group);
 
         if (entry != null)


### PR DESCRIPTION
- Unity 2022.3.38f1
- com.littlebigfun.addressable-importer v0.16.1
- com.unity.addressables v1.21.21

When an Addressable asset entry is manually removed from the Addressables Groups window, reimporting the asset (" Check Folder") .logs "Entry created/updated for ..." but the asset does not reappear in its group . the inspector shows no Addressable checkbox.

Manually removing an entry from the Groups window leaves behind a "zombie entry" in AddressableAssetSettings.FindAssetEntry still returns a non-null AddressableAssetEntry, and its parentGroup property still references the original group. 

https://github.com/favoyang/unity-addressable-importer/blob/4586e788bf2f7138af6ebffb3646dc6cdaaad544/Editor/AddressableImporter.cs#L249

Fix
Added a third check that verifies the entry is actually present in the group's entries collection
```
var isInGroup = entry != null && entry.parentGroup != null && entry.parentGroup.entries.Contains(entry);
if (entry == null || entry.parentGroup != group || !isInGroup)
    entry = settings.CreateOrMoveEntry(guid, group);
```